### PR TITLE
Update proc_creation_lnx_usermod_susp_group.yml

### DIFF
--- a/rules/linux/process_creation/proc_creation_lnx_usermod_susp_group.yml
+++ b/rules/linux/process_creation/proc_creation_lnx_usermod_susp_group.yml
@@ -1,7 +1,7 @@
 title: User Added To Root/Sudoers Group Using Usermod
 id: 6a50f16c-3b7b-42d1-b081-0fdd3ba70a73
 status: test
-description: Detects usage of the "usermod" binary to add users add users to the root or suoders groups
+description: Detects usage of the "usermod" binary to add users to the root or sudoers groups
 references:
     - https://pberba.github.io/security/2021/11/23/linux-threat-hunting-for-persistence-account-creation-manipulation/
     - https://www.configserverfirewall.com/ubuntu-linux/ubuntu-add-user-to-root-group/


### PR DESCRIPTION
Fixed what appears to be a typo, "add users" was repeated and sudoers was spelled "suoders".